### PR TITLE
Added Golf controller, .* instead of :any as a routing rule - closes #8

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -10,7 +10,7 @@ $config['menu_choices'] = array(
         array('name' => 'Delta', 'link' => '/delta/force'),
         array('name' => 'Echo', 'link' => '/echo/must/wehave'),
         array('name' => 'Foxtrot', 'link' => '/foxtrot'),
-        array('name' => 'Golf', 'link' => '#'),
+        array('name' => 'Golf', 'link' => '/i/need/a/hobby'),
         array('name' => 'Hotel', 'link' => '#'),
         array('name' => 'India', 'link' => '/india'),
         array('name' => 'Juliet', 'link' => '/juliet'),

--- a/application/config/routes.php
+++ b/application/config/routes.php
@@ -54,3 +54,4 @@ $route['404_override'] = '';
 $route['translate_uri_dashes'] = FALSE;
 $route['foxtrot'] = 'tango';
 $route['show/(:any)'] = 'welcome/show/$1';
+$route['i/.*'] = 'golf';

--- a/application/controllers/Golf.php
+++ b/application/controllers/Golf.php
@@ -1,0 +1,17 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Golf extends Application
+{
+
+	function __construct()
+	{
+		parent::__construct();
+	}
+
+	public function index()
+	{
+		$this->show(6);
+	}
+
+}

--- a/changelog.md
+++ b/changelog.md
@@ -39,3 +39,8 @@ Changelog format: [Markdown](https://github.com/adam-p/markdown-here/wiki/Markdo
 ###2017-09-28 4:50PM
 ##Added
 - Added Juliet controller.
+
+###2017-09-28 9:10PM
+##Added
+- Added Golf controller.
+- Added .* instead of :any as a routing rule to Golf controller.


### PR DESCRIPTION
Hey Captain Hansol,
- Added Golf controller
- Used _.*_ instead of _:any_ as a routing rule to Golf controller to match any character repeated as many times as needed
- Tested with _/i/need/a/hobby_ and maps to page properly